### PR TITLE
Inject error: Break WelcomePopup Continue button

### DIFF
--- a/src/components/WelcomePopup.vue
+++ b/src/components/WelcomePopup.vue
@@ -90,7 +90,7 @@
         </v-row>
       </v-container>
     </v-form>
-    <button @click="closePopup"
+    <button @click="closPopup"
       style="margin-left: 12px; height: 60px; width: 200px; border-radius: 40px; border: solid #1c548d"
       >Continue</button>
   </div>


### PR DESCRIPTION
Introduced a typo in the Continue button's click handler to simulate a common developer error. Changed @click="closePopup" to @click="closPopup" (missing 'e'), which will cause the button to fail since the method doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)