### PR TITLE
Inject error: Break home page navigation buttons

### DIFF
--- a/src/pages/IndexHome.vue
+++ b/src/pages/IndexHome.vue
@@ -45,7 +45,7 @@
               outlined
               height="60px"
               width="230px"
-              @click="scrollTo(link.to)"
+              @click="scrolTo(link.to)"
             >
               {{ link.title }}
             </v-btn>


### PR DESCRIPTION
Introduced a typo in the "Learn more" navigation buttons on the home page. Changed @click="scrollTo(link.to)" to @click="scrolTo(link.to)" (missing one 'l'), which will break all three navigation buttons (Club Info, Events, Resources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)